### PR TITLE
V4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,6 @@
 __pycache__
 .venv
 
-# csv files
-calendar.csv
-email_table.csv
-
-# xlsx files
-~$email_table.xlsx
-email_table.xlsx
-
 # auth/config
 credentials.json
 emails.json
@@ -16,8 +8,11 @@ emails_1.json
 parameters.json
 sa-file.json
 
-#random
-test.py
+# random
 development/
-EMO'S.txt
-SCOOT INN.txt
+csv_files/
+xlsx_files/
+txt_outputs/
+
+# deprecated 
+deprecated

--- a/calendar_generator.py
+++ b/calendar_generator.py
@@ -1,185 +1,251 @@
-import os, requests, csv, sys
-from datetime import datetime, timedelta
+import requests, re, sys, os, json, csv, time
 from bs4 import BeautifulSoup
-from openpyxl import Workbook, load_workbook
-from openpyxl.styles import PatternFill
+from datetime import datetime, timedelta
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
-# Set up lists to select venues and build information tables
-print("Setting up the lists...")
-print()
-venues = ["EMO'S", "SCOOT INN"]
-output = []
-table = []
-date_events = {}
+config = json.load(open("config_files/parameters.json"))
 
-# Compile all the data
-def compile_info():
-    print()
-    print("Compiling info for", venue.title()+ ":")
-    # Get the date of the event
-    current_month = datetime.now().month
-    event_months = soup.find_all('span', class_='eventMonth')
-    event_days = soup.find_all('span', class_='eventDay')
-    combined_dates = []
-
-    # Establish the year and build the date variable
-    for event_month, event_day in zip(event_months, event_days):
-        if datetime.strptime(event_month.text, "%b").month < current_month:
-            year += 1
-        else:
-            year = datetime.now().year
-        month_numerical = datetime.strptime(event_month.text, "%b").month
-        date = f"{year}-{month_numerical:02d}-{event_day.text}T00:00:00.000Z"
-        combined_dates.append(date)
-        year = datetime.now().year
-    # Set up variables for event date list, door time list, datetime for now, next month and the month after
-    combined_dates = sorted(list(set(combined_dates)), key=lambda x: datetime.strptime(x, "%Y-%m-%dT%H:%M:%S.000Z"))
-    doors = soup.find_all('span', itemprop='doorTime')
-    now = datetime.now()
-    first_next_month = (now + timedelta(days=30)).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    first_after_next = (now + timedelta(days=60)).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-
-    # Set up the output for the CSV files
+# Build the event_data dictionary that will populate venues_info[venue]['event_info']
+def create_event_data(event_title, start_date, call_time, doors_time, end_date, end_time, location, venue):
     i = 0
-    for artist in artists:
-        description = f"=CONCATENATE(H{len(output) + 2},UPPER(I{len(output) + 2}))"
-        start_date = datetime.strptime(combined_dates[i], "%Y-%m-%dT%H:%M:%S.%fZ").date()
-        # Isolate the shows for only next month
-        if start_date >= first_next_month.date() and start_date < first_after_next.date():
-            if i >= 0 and i < len(doors) and i < len(artists):
-                combined = []
-                # If the show has MOVED TO in the event title, indicating the date and/or venue location has changed
-                if "MOVED TO" in artist.get_text():
-                    doors.insert(i, "N/A")
-                    doors_time = "N/A"
-                    call_time = "N/A"
-                    end_time = "N/A"
-                    end_date = "N/A"
-                # Otherwise, build the main lists for the remaining shows
+    event_data = {
+        'start_date': start_date.strftime('%Y-%m-%d'),
+        'subject': event_title,
+        'start_time': call_time,
+        'end_time': end_time,
+        'end_date': end_date,
+        'location': location,
+        'venue': venue,
+        'description': f"=CONCATENATE(I{i + 2},UPPER(J{i + 2}))",
+        'description_1': f"DOORS TIME: {doors_time}\n VENUE: {venue}\n MERCH COORDINATOR:",
+        'merch_coordinator': None
+    }
+    venues_info[venue]['event_info'].append(event_data)
+    # print(event_data)
+    i += 1
+
+    # Create the email_tables
+    create_email_table(event_title, start_date, call_time, venue)
+    return event_data
+
+# Export data to CSV file
+def write_csv():
+    # Set up headers for the CSV file used to create the schedule and the table emailed to the team
+    print("\nSetting up the CSV headers...\n")
+    headers = ['start_date','subject', 'start_time', 'end_time', 'end_date', 'location', 'venue', 'description', 'description_1', 'merch_coordinator']
+
+    # Generate calendar.csv in the ./csv_files folder that wil be used to create the schedule in a format that can be imported in Google Calendars
+    print("Creating csv_files/calendar.csv...\n")
+    with open('csv_files/calendar.csv', 'w', newline='', encoding='utf-8') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=headers)
+        writer.writeheader()
+
+        for venue in venues_info:
+            all_event_data = venues_info[venue]['event_info']
+            for event_data in all_event_data:
+                writer.writerow(event_data)
+    print("Exported to " + os.getcwd() + "csv_files/calendar.csv\n")
+
+# Build the email_data dictionary that will be emailed to the team
+def create_email_table(event_title, start_date, call_time, venue):
+    email_data = {
+        'Artist': event_title,
+        'Date': start_date.strftime('%Y-%m-%d'),
+        'Call Time': call_time,
+        'Venue': venue,
+        }
+    venues_info[venue]['email_data'].append(email_data)
+    print(event_title, "||", start_date.strftime('%Y-%m-%d'), "||", call_time, "||", venue)
+    return email_data
+
+venues_info = {
+    "EMO'S": {
+        'url': "https://www.emosaustin.com/events-calendar",
+        'location': "2015 E Riverside Dr, Austin, TX 78741",
+        'event_info': [],
+        'email_data': []
+    },
+    "SCOOT INN": {
+        'url': "https://scootinnaustin.com/calendar",
+        'location': "1308 E 4th St, Austin, TX 78702",
+        'event_info': [],
+        'email_data': []
+    },
+}
+
+concurrent_shows = {
+    "shows": []
+}
+
+# Compile all the event info
+def compile_info():
+    for venue, info in venues_info.items():
+        print("\nGetting all the events from " + venue.title() + " for next month...\n")
+
+        response = requests.get(info['url'])        
+        if response.status_code == 200:
+            soup = BeautifulSoup(response.content, 'html.parser')
+
+            # # Uncomment the following lines to print the soup variable to txt files named after the corresponding 
+            # # venue and see exactly what you are parsing. The files have been added to the .gitignore.
+            # with open(f'txt_outputs/venue_data/{venue}_code.txt', 'w', encoding='utf-8') as python_output:
+            #     sys.stdout = python_output
+            #     print(soup)
+            # sys.stdout = sys.__stdout__
+
+            event_elements = soup.find_all('div', class_='frontgateFeedSummary')
+            for event_element in event_elements:
+                # Artist/Event name
+                event_title = event_element.find('h2', class_='contentTitle').text.strip()                
+                
+                # Start date info
+                month_element = event_element.find('span', class_='eventMonth').text.strip()
+                day_element = event_element.find('span', class_='eventDay').text.strip()
+                current_month = datetime.now().month
+                year = datetime.now().year                
+                if datetime.strptime(month_element, "%b").month < current_month:
+                    year += 1
                 else:
-                    doors_time = datetime.strptime(doors[i].get_text()[15:].lstrip(), '%I:%M %p')
-                    # print(doors_time)
-                    call_time = (doors_time - timedelta(hours=1))
-                    end_dt = datetime.combine(start_date, doors_time.time()).strftime('%Y-%m-%d %I:%M %p')
-                    end_datetime = (datetime.strptime(end_dt, '%Y-%m-%d %I:%M %p') + timedelta(hours=5)).strftime('%Y-%m-%d %I:%M %p')
-                    end_time = end_datetime[end_datetime.index(" "):].lstrip()
-                    end_date = end_datetime[0:end_datetime.index(" ")]
-                # Start building the event tables that will be used to make the schedule and email the team
-                event = [start_date, artist.get_text().replace("â€™", "'"), call_time.time().strftime("%I:%M %p"), venue]
-                combined.extend([start_date, artist.get_text(), call_time.time().strftime("%I:%M %p"), end_time, end_date, location, description])
-                combined.append(("Doors: " + doors_time.time().strftime("%I:%M %p") + "\nVenue: " + venue + "\nMerch Coordinator: ").upper())
-                output.append(combined)
-            else:
-                # Handle the case when the index i is out of range for doors or artists
-                print("\n!!! INDEX OUT OF RANGE FOR DOORS OR ARTISTS:", i, "!!!\n")
-                print("What does this mean? This means that there most likely may be some data missing so you'll want to check over your csv files and first make sure that all your events are listed. Next, make sure all the event dates and doors time are correct to the event as listed on the venues' event calendar webpages. Add any events that may have gotten skipped and adjust any door times as needed.\n")
-            # Build table for event date comparison
-            if start_date not in date_events:
-                date_events[start_date] = []
-            date_events[start_date].append(event)
-            print("The following show needs to be staffed:", event)
-        i += 1
+                    year = datetime.now().year
+                month_numerical = datetime.strptime(month_element, "%b").month
+                start_date_str = f"{year}-{month_numerical:02d}-{day_element}T00:00:00.000Z"
+                start_date = datetime.strptime(start_date_str, "%Y-%m-%dT%H:%M:%S.%fZ").date()
 
-# Set the venues to process for the script
-print("Setting up the venues for this script. The venues for this script are "  + ", ".join([venue.title() for venue in venues]) + ".")
-for venue in venues:
-    if venue == "EMO'S":
-        url = requests.get("https://www.emosaustin.com/events-calendar")
-        location = "2015 E Riverside Dr, Austin, TX 78741"
-    elif venue == "SCOOT INN":
-        url = requests.get("https://scootinnaustin.com/calendar")
-        location = "1308 E 4th St, Austin, TX 78702"
-    # You should never see the following!
+                # Buy link (used in the event doors time not listed on venue event page)
+                buy_button = event_element.find('a', class_='button buyButton')
+                buy_link = buy_button['href']
+                if "ticketmaster" in buy_link:
+                    buy_link = buy_link.replace("www.ticketmaster.com", "concerts.livenation.com")
+                
+                # Doors time info (this logic is for the shows that display doors time on the event page)
+                door_time = event_element.find('span', itemprop='doorTime')
+                doors = door_time.text.strip() if door_time else ""
+                doors_time_match = re.search(r'Doors open at\s+(\d{1,2}:\d{2}\s+[APap][Mm])', doors)
+                doors_time_str = doors_time_match.group(1) if doors_time_match else "N/A"
+
+                # Filter all the shows for next month
+                filter_next_month(event_title, start_date, buy_link, doors_time_str, info['location'], venue)
+        else:
+            print("Failed to fetch the HTML content. Status code:", response.status_code)
+
+# Search for doors time that are missing from event pages
+def find_doors_time(tickets):
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36',
+        "Cookie": f'{config["cookie"]}'
+    }
+    ticket_link = requests.get(tickets, headers=headers)        
+    if ticket_link.status_code == 200:
+        ticket_info = BeautifulSoup(ticket_link.content, 'html.parser')
+        date_div = ticket_info.find('div', class_='event-header__event-date')
+        if date_div == None:
+            # This logic was created for www.zeffy.com
+            description_tags = ticket_info.find_all('meta', attrs={'name': 'description'})
+            doors_time_pattern = r'(\d{1,2}(:\d{2})?\s*[APap][Mm])'
+            match = re.search(doors_time_pattern, description_tags[0]['content'])
+            if match:
+                time = match.group(1)
+                time_obj = datetime.strptime(time, '%I%p')
+                doors_time = time_obj.strftime('%I:%M %p')
+                doors_time = doors_time.strip()
+                return doors_time
+            elif not match:
+                # This logic was created for austin.rnbonly.com
+                second_ticket_link = ticket_info.find('a', class_='button n01')
+                browser = webdriver.Chrome()
+                browser.get(second_ticket_link['href'])
+                time_search = WebDriverWait(browser, 30).until(EC.presence_of_element_located((By.XPATH, "//div[@class='event-item-single__time']")))
+                search = time_search.text
+                doors_time = search[0:7]
+                doors_time.strip()
+                browser.quit()
+                return doors_time
+            else:
+                doors_time = '0:00 PM'
+                print("Doors time not found. You'll need to inspect the code of the ticket info page, and add a condition specific to that page.")
+                # print(tickets)
+                return doors_time
+        else:
+            time_text = date_div.get_text()
+            doors_time = time_text.split(' • ')[-1]
+            doors_time = doors_time.strip()
+            return doors_time
+
+        # # The following will generate a file for each show with the data from the buy ticket page when uncommented.
+        # # This will make the script execute a more slowly, but helpful if you need to look at the data you're parsing.
+        #  with open(f'txt_outputs/{show}_code.txt', 'w', encoding='utf-8') as python_output:
+        #     sys.stdout = python_output
+        #     print(ticket_info)
+        # sys.stdout = sys.__stdout__
+
+# Format doors_time_str as datetime object and calculate call_time, end_time, and end_date
+def format_times(start_date, doors_time_str, buy_link):
+    if doors_time_str != "N/A":
+        unformatted_doors_time = datetime.strptime(doors_time_str, "%I:%M %p")
     else:
-        print("No more venues! Check your venue list because you shouldn't see this!")
+        # Since doors_time N/A from event page, go to ticket info page
+        doors_time = find_doors_time(buy_link)
+        unformatted_doors_time = datetime.strptime(doors_time, "%I:%M %p")
 
-    # Get all the HTML data from the Emo's and Scoot Inn event web pages and execute compile_info()
-    soup = BeautifulSoup(url.content, 'html.parser')
+    doors_time = unformatted_doors_time.strftime("%I:%M %p")
+    unformatted_call_time = unformatted_doors_time - timedelta(hours=1)
+    call_time = unformatted_call_time.strftime("%I:%M %p")
+    end_dt = datetime.combine(start_date, unformatted_doors_time.time()).strftime('%Y-%m-%d %I:%M %p')
+    end_datetime = (datetime.strptime(end_dt, '%Y-%m-%d %I:%M %p') + timedelta(hours=5)).strftime('%Y-%m-%d %I:%M %p')
+    end_time = end_datetime[end_datetime.index(" "):].lstrip()
+    end_date = end_datetime[0:end_datetime.index(" ")]
+    # Format doors_time in HH:MM AM/PM format
+    doors_time = unformatted_doors_time.strftime("%I:%M %p") if unformatted_doors_time else "N/A"
 
-    # Uncomment the following lines to print the soup variable to txt files named after the corresponding 
-    # venue and see exactly what you are parsing
-    # with open(f'{venue}.txt', 'w', encoding='utf-8') as python_output:
-    #     # Redirect the standard output to the file
-    #     sys.stdout = python_output
-    #     print(soup)
-    # # Restore the default standard output
-    # sys.stdout = sys.__stdout__
+    return doors_time, call_time, end_time, end_date
 
-    artists = soup.find_all('h2', itemprop='name')
-    compile_info()
+# Filter on the shows for next month
+def filter_next_month(event_title, start_date, buy_link, doors_time_str, location, venue):
+    today = datetime.now()
+    next_month_first_day = (today + timedelta(days=32)).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    month_after_next_first_day = (today + timedelta(days=62)).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    start_date = datetime.combine(start_date, datetime.min.time())
 
-# Identify dates when there are shows at both venues
-print()
-print("Identifying dates where both venues have a show...")
-print()
-for date, events in date_events.items():
-    if len(events) > 1:
-        for event in events:
-            if event[3] == "EMO'S":
-                event.append("CONCURRENT SHOW AT SCOOT INN")
-            elif event[3] == "SCOOT INN":
-                event.append("CONCURRENT SHOW AT EMO'S")
-            # You should never see the following!
-            else:
-                print("What d'ya want from me?")
-    table.extend(events)
+    # Find all the shows for next month and create the event_data tables
+    if next_month_first_day <= start_date and start_date < month_after_next_first_day:
+        # Convert doors_time_str to a datetime object and calculate call_time, end_time, and end_date
+        doors_time, call_time, end_time, end_date = format_times(start_date, doors_time_str, buy_link)
+        # Start putting all the event data together
+        create_event_data(event_title, start_date, call_time, doors_time, end_date, end_time, location, venue)
 
-# Set up headers for the CSV file used to create the schedule and the table emailed to the team
-print("Setting up the CSV headers...")
-print()
-header = ['Start Date', 'Subject', 'Start Time', 'End Time', 'End Date', 'Location', 'Description',  'Description_1', 'Merch Coordinator']
-email_header = ['Start Date', 'Subject', 'Start Time', 'Venue', 'Notes']
+# Start compiling the show details
+compile_info()
 
-# Generate email_table.csv in the ./csv_files folder that will be used to email the Merch Coordinators
-print("Creating csv_files/email_table.csv")
-with open('csv_files/email_table.csv', 'w', encoding='UTF8', newline='') as f:
-    writer = csv.writer(f)
-    writer.writerow(email_header)
-    for show in table:
-        if any(field for field in show):
-            writer.writerow(show)
-print("Exported to " + os.getcwd() + "csv_files/email_table.csv")
-print()
+# Find dates when there are concurrent shows at venues
+def find_concurrent_shows(*args):
+    for arg in args:
+        emos_dates = set(data['start_date'] for data in venues_info["EMO'S"]['event_info'])
+        scoot_inn_dates = set(data['start_date'] for data in venues_info["SCOOT INN"]['event_info'])
 
-# Generate calendar.csv in the ./csv_files folder that wil be used to create the schedule in a format that can be imported in Google Calendars
-print("Creating csv_files/calendar.csv")
-with open('csv_files/calendar.csv', 'w', encoding='UTF8', newline='') as f:
-    writer = csv.writer(f)
-    writer.writerow(header)
-    for combo in output:
-        if any(field for field in combo):
-            writer.writerow(combo)
-print("Exported to " + os.getcwd() + "csv_files/calendar.csv")
-print()
+    common_dates = emos_dates.intersection(scoot_inn_dates)
+    sorted_dates = sorted(common_dates)
+    print("\nThe following dates have shows at all venues:", sorted_dates ,'\n')
 
-# Load the CSV file
-with open('csv_files/email_table.csv', 'r', newline='') as f:
-    reader = csv.reader(f)
-    rows = list(reader)
+    print("Those corresponding shows are:\n")
+    for date in sorted_dates:
+        for venue in venues_info:
+            number_of_events = len(venues_info[venue]['event_info'])
+            
+            for i in range(number_of_events):
+                event_info = venues_info[venue]['event_info'][i]
+                venue_start_date = event_info['start_date']
+                event_name = event_info['subject']
+                event_start_time = event_info['start_time']
+                if venue_start_date == date:
+                    same_shows = [event_name, venue_start_date, event_start_time, venue]
+                    concurrent_shows['shows'].append(same_shows)
+                    print(event_name, "||", venue_start_date, "||", event_start_time, "||", venue)
 
-# Create a new Excel workbook and worksheet
-wb = Workbook()
-ws = wb.active
+# Find concurrent shows
+find_concurrent_shows(venues_info["EMO'S"]['event_info'], venues_info["SCOOT INN"]['event_info'])
 
-# Write the rows to the worksheet
-for row in rows:
-    ws.append(row)
-
-# Remove empty rows
-for i in reversed(range(1, ws.max_row + 1)):
-    if all([cell.value is None for cell in ws[i]]):
-        ws.delete_rows(i)
-
-# Set the fill color and font color for the "Same Date" rows
-fill = PatternFill(start_color='4f81bd', end_color='4f81bd', fill_type='solid')
-font_color = 'fff2cc'
-
-# Loop through the rows and highlight the "Same Date" rows
-for row in ws.iter_rows(min_row=2, min_col=1, max_col=5):
-    if row[4].value == "CONCURRENT SHOW AT SCOOT INN" or row[4].value == "CONCURRENT SHOW AT EMO'S":
-        for cell in row:
-            cell.fill = fill
-            cell.font = cell.font.copy(color=font_color)
-
-# Save the workbook to a file
-wb.save('xlsx_files/email_table.xlsx')
+# Write the CSV
+write_csv()

--- a/config_files/sample_parameters.json
+++ b/config_files/sample_parameters.json
@@ -5,5 +5,6 @@
     "redirect_uri": "https://redirect./app/UserHome",
     "scope": "Mail.Send",
     "tenant": "TENANT_ID",
-    "token_endpoint": "https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/token"
+    "token_endpoint": "https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/token",
+    "cookie": "COOKIE_FROM_LIVENATION"
 }

--- a/readme.MD
+++ b/readme.MD
@@ -1,19 +1,51 @@
-# Merch Coordinator Automator v3.0
+# Merch Coordinator Automator v4.0
 
-This repository is for the work I do at the LiveNation venues Emo's and the Historic Scoot Inn in Austin, TX. I simply created this project to improve my Python skills, and assist with my tasks as the manager for the Merch Coordinators. The original implementation of this project was just the `calendar_generator.py` script, which would produce a `csv` called `calendar.csv` that contained the information for all shows on the Emo's and Scoot Inn calendars found on their respective websites. This has since been expanded to include scripts that will take that information and email a table of just the shows for next month to all the Merch Coordinators using either Gmail or Outlook365.  In this version, the event dates are no longer retrieved using `dates = soup.find_all('meta', itemprop = 'startDate')`, but rather by the `eventMonth` and `eventDay` tags with some additional logic for improved accuracy for the event dates.
+The Merch Coordinator Automator was created specifically for the LiveNation venues Emo's and the Historic Scoot Inn in Austin, TX to assist in the creation of the schedule for the Merch Coordinators. The original implementation of this project was just the `calendar_generator.py` script, which would produce a `csv` called `calendar.csv` that contained the information for all shows on the Emo's and Scoot Inn event pages.
+
+This has since been expanded to include scripts that will take that information and email a table of the shows for next month to all the Merch Coordinators. Scripts have been added to use either Gmail or Outlook365, but does require access to Google Cloud for GMail and/or Azure for O365 depending on your preference. In this version, the event dates are no longer retrieved using `dates = soup.find_all('meta', itemprop = 'startDate')`, but rather by the `eventMonth` and `eventDay` tags with some additional logic for improved accuracy for the event dates.
 
 ## Summary
 
-`cal_emailer_gmail.py` and `cal_emailer_o365.py` will invoke `calendar_generator.py`, which will scrape the calendars on the [Emo's ](https://www.emosaustin.com/events-calendar) and [Scoot Inn](https://scootinnaustin.com/calendar) websites to generate a couple of `csv` files with the information needed to create the schedule for the Merch Coordinators. In the process, there will be 2 files created that are included in the `.gitignore` - `csv_files/email_table.csv` and `csv_files/calendar.csv`.
+`cal_emailer_gmail.py` and `cal_emailer_o365.py` will invoke `calendar_generator.py`, which will scrape the calendars on the [Emo's ](https://www.emosaustin.com/events-calendar) and [Scoot Inn](https://scootinnaustin.com/calendar) websites to generate a `csv` file with the information needed to create the schedule for the Merch Coordinators - `csv_files/calendar.csv`. This file is included in the `.gitignore`.
 
-`csv_files/email_table.csv` will be used to create the table that is emailed the Merch Coordinators with the shows coming up next month that need to be staffed with just the date, artist, time, venue, and notes. Logic has been added in this version to identify dates where there are shows at both venues and to then make note of that in the table in the email that is sent to the Merch Coordinators. This ends up creating `xlsx_files/email_table.xlsx` with the rows highlighted for dates when there are concurrent shows. This is the table that then gets emailed to the team. 
+`csv_files/calendar.csv` is generated in a format that can be quickly modified and imported into Google Calendar using [the format expressed in the documentation here](https://support.google.com/calendar/answer/37118?hl=en&co=GENIE.Platform%3DDesktop#zippy=%2Ccreate-or-edit-a-csv-file).
 
-`csv_files/calendar.csv` is a little more expansive and generated in a format that can then be quickly modified and imported into Google Calendar using [the format expressed in the documentation here](https://support.google.com/calendar/answer/37118?hl=en&co=GENIE.Platform%3DDesktop#zippy=%2Ccreate-or-edit-a-csv-file).
+### GET THE COOKIE - REQUIRED!!!
 
+The way the script was previously structured led to some errors that essentially rendered the script completely ineffective, so it had to be restructured to account for some missing data - more specifically missing doors times. Logic was added to take the link from the `Buy Tickets` button and parse that ticket info page for the doors time.
+
+However, to do this requires authentication in the form of a cookie retrieved from the request headers. While getting that cookie was unsuccessfully attempted through code, for the time being, it has to be done manually. To do this, follow these steps:
+
+1. Open your browser with developer tools up and the `Network Tab` selected
+2. Navigate to https://www.emosaustin.com/events-calendar
+3. Click any of the `Buy Tickets` buttons and make sure it directs you to `concerts.livenation.com` page
+4. Locate `tmauthadaptor.js` on the left side of the developer tools and click it 
+5. Collapse `General` and `Response Headers` or scroll down to `Request Headers`
+6. Highlight the entire cookie and copy it
+    - It begins with `mt.v=...` and ends at the line above `Host: identity.livenation.com`
+7. Open `/config_files/sample_parameters.json` and replace `COOKIE_FROM_LIVENATION` with the cookie by pasting it
+    - The cookie is good for about 5 minutes at which point you'll have to hit refresh so keep that page open if necessary!
+
+FAILURE TO COMPLETE THE ABOVE STEPS WILL RESULT IN THE FOLLOWING ERROR:
+
+```
+  File "merch_coordinator_automator/calendar_generator.py", line 191, in format_times     
+    unformatted_doors_time = datetime.strptime(doors_time, "%I:%M %p")
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+TypeError: strptime() argument 1 must be str, not None
+```
+
+That's because TicketMaster and `concerts.livenation.com` require the authentication provided by that cookie. Otherwise, `date_div = ticket_info.find('div', class_='event-header__event-date')` will come back `None`, and that is exactly what the error is pointing out. At this point, you're good to continue running the script!
+
+If you'd just like to run the `calendar_generator.py` script, complete the top of the `Getting Started` up through `pip install -r requirements.txt`, and simply execute:
+
+`python calendar_generator.py`
+
+This will run just that script and display the shows at both venues for next month as well as the concurrent shows. To send an email that uses that script to prepare and communicate that info to the team, continue on.
 
 ## Getting started
 
-To get started, you'll need to setup a virtual environment using Python 3 and activate it to install the neccesary dependencies like such:
+To get started, you'll need to setup a virtual environment using Python 3 and activate it to install the necessary dependencies like such:
 
 In Windows, use:
 
@@ -33,7 +65,7 @@ pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-`requirements.txt` has all the necessary dependencies and indicates which script uses which depencies. 
+`requirements.txt` has all the necessary dependencies and indicates which script uses which dependencies. 
 
 ### Setup `emails.json`
 
@@ -95,7 +127,7 @@ Simply use `config_files\sample_emails.json` as a template and modify as needed!
 
 ### For `cal_emailer_gmail.py`
 
-For this implementation, I have 2FA enabled on my account. `cal_emailer_gmail.py` was taken and modified from [this post on StackOverflow](https://stackoverflow.com/a/43379469). You will need access to the Google Cloud Platorm (GCP) for authentication in order to execute this script. Once you have access to https://console.cloud.google.com/, execute the following steps:
+For this implementation, I have 2FA enabled on my account. `cal_emailer_gmail.py` was taken and modified from [this post on StackOverflow](https://stackoverflow.com/a/43379469). You will need access to the Google Cloud Platform (GCP) for authentication in order to execute this script. Once you have access to https://console.cloud.google.com/, execute the following steps:
 
 1. [Navigate here to enable the api you need](https://console.developers.google.com/apis/)
 
@@ -123,7 +155,7 @@ For this implementation, I have 2FA enabled on my account. You will need access 
 
 1. [Navigate here to create an app registration](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)
 
-2. Enter Name, Supported Account Types (for this implementation, I used Accounts in any organizational directory (Any Azure AD directory - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)), any Redirect URI, and click the Register Button. 
+2. Enter Name, Supported Account Types (for this implementation, I used Accounts in any organizational directory (Any Azure AD directory - Multi-tenant) and personal Microsoft accounts (e.g. Skype, Xbox)), any Redirect URI, and click the Register Button. 
 
 3. Once directed to the app registration Overview page, copy the `client_id` and the `tenant_id` and paste them over `CLIENT_ID` and `TENANT_ID` respectively in `./config_files/sample_parameters.json`.
 
@@ -151,7 +183,7 @@ Once everything is in place, simply execute:
 python cal_emailer_o365.py
 ```
 
-A browser window will open up for you to authenticate your machine. Just follow the instructions, and once you've logged into your account you'll be directed to your Outlook365 inbox - keep this window open for 15 seconds after which the email will be sent to the specified recipients.
+A browser window will open up for you to authenticate your machine. Just follow the instructions, and once you've logged into your account you'll be directed to your Outlook365 inbox - keep this window open for 15 seconds after which the email will be sent to the specified recipients. If you're already logged into your account, it may just take you right to your inbox so just give the scripts a few seconds to finish running.
 
 If for some reason, you're having network issues, and 15 seconds isn't long enough for the script to authenticate and log in, update line 33 in the `cal_emailer_o365.py` script:
 
@@ -163,14 +195,14 @@ time.sleep(15)
 
 ### ISSUE:
 
-When working on version 2 of this script, I noticed in February and March of 2023 that it appeared to be skipping over events happening on the first of the month. While there was no error to indicate why this was happening because the script was techincally working correctly, the following variables establishing the first of the next two months had to be adjusted:
+When working on version 2 of this script, I noticed in February and March of 2023 that it appeared to be skipping over events happening on the first of the month. While there was no error to indicate why this was happening because the script was technically working correctly, the following variables establishing the first of the next two months had to be adjusted:
 
 ```
     first_next_month = (now + timedelta(days=30)).replace(day=1)
     first_after_next = (now + timedelta(days=60)).replace(day=1)
 ```
 
-The reason for this was because the `startDate` in the `html` output appears in the following format: `2023-03-01T00:00:00.000Z`. The timestamps are usually `00:00:00.000Z` as shown in the example so this meant that if I set `first_next_month = (now + timedelta(days=30)).replace(day=1)`, the timestamp for the first of next month would be set to at whatever time I ran the script. For example, if I ran the script mid-Febraury sometime around 4:15 PM, then `first_next_month = 2023-03-01T16:15:23:000Z`, and if the `startDate` for an event on the first of next month is `2023-03-01T00:00:00.000Z`, this means that when the script will skip that event entirely when executing the following logic: `if start_date >= first_next_month.date() and start_date < first_after_next.date():`.
+The reason for this was because the `startDate` in the `html` output appears in the following format: `2023-03-01T00:00:00.000Z`. The timestamps are usually `00:00:00.000Z` as shown in the example so this meant that if I set `first_next_month = (now + timedelta(days=30)).replace(day=1)`, the timestamp for the first of next month would be set to at whatever time I ran the script. For example, if I ran the script mid-February sometime around 4:15 PM, then `first_next_month = 2023-03-01T16:15:23:000Z`, and if the `startDate` for an event on the first of next month is `2023-03-01T00:00:00.000Z`, this means that when the script will skip that event entirely when executing the following logic: `if start_date >= first_next_month.date() and start_date < first_after_next.date():`.
 
 ### SOLUTION:
 
@@ -185,7 +217,7 @@ This has been resolved and should not present any issues - this is strictly for 
 
 ### ISSUE:
 
-I encountered the following error while prerparing the calendar and schedule for August 2023:
+I encountered the following error while preparing the calendar and schedule for August 2023:
 
 ```
     doors_time = datetime.strptime(doors[i].get_text()[15:].lstrip(), '%I:%M %p')
@@ -195,11 +227,11 @@ IndexError: list index out of range
 
 ### EXPLANATION
 
-After reviewing the script carefully, I couldn't see any issue with the script itself and printed out the doors variable: `print(doors)`. I noticed that there were only 5 door times listed for all the shows listed at the Scoot Inn Event Calendar Page, and upon visiting the site, noticed that there were only door times listed for 5 events. Furthermore, since the door times are for 5 events over several months, the times would not align correctly with the other event details because of how the script is structured. That is to say that for the time being, this script only works if all the data is present - mainly event/artist name, event date and the doors time.
+After reviewing the script carefully, I couldn't see any issue with the script itself and printed out the doors variable: `print(doors)`. I noticed that there were only 5 door times listed for all the shows listed at the Scoot Inn Event Calendar Page, and upon visiting the site, noticed that there were only door times listed for 5 events. Furthermore, since the door times are for 5 events over several months, the times would not align correctly with the other event details because of how the script is structured. This has been resolved in version 4 of this application by adding the find_doors_time() function, which utilizes the `Buy Tickets` link to get the doors time directly from the ticket information page via TicketMaster/concerts.livenation.
 
 ### SOLUTION
 
-As a temporary, possibly permanent measure, the logic - `if i >= 0 and i < len(artists):` - has been updated and expanded to:
+As a workaround for version 3 of this application, the logic - `if i >= 0 and i < len(artists):` - had been updated and expanded to:
 
 ```
 if i >= 0 and i < len(doors) and i < len(artists):
@@ -212,6 +244,6 @@ else:
 
 ```
 
-Better error handling may be added in future versions, but for now, be sure you're getting all the data you need and this should go without saying, but always double check the information!
+This is no longer an issue in version 4 of this application as the script has been entirely refactored. Just be sure you're getting all the data you need and always double check the information!
 
-And that's it for now - this should cover everything to generate the calendar and create the merch coordinator schedule for next month!
+That's it for now - this should cover everything to generate the calendar and create the merch coordinator schedule for next month!

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,9 @@ google-auth-oauthlib
 # Needed for calendar_generator.py
 bs4
 requests
-openpyxl
+selenium
 
 # Needed for cal_emailer_google.py
-tabulate
 httplib2
 oauth2client
 apiclient


### PR DESCRIPTION
The following changes occurred in the v4.0 rewrite:

- broke up previous script into individual functions
- added logic to determine dates with shows at both venues
- added write_csv and find_doors_time functions
- updated event_data and email_data dicts
- expanded doors time search to include non-TicketMaster/LiveNation sites
- officially deprecated previous calendar_generator.py script
- refactored compile_info function
- reordered filter_next_month and doors_time search so the filter goes first
- added format_times function to format the doors time and break down compile_info function
- updated Outlook365 email message
- started removing unused dependencies
- updated GMail script with messaging to match Outlook365
- removed concurrent_dates list as it was determined to be unnecessary
- sorted common_dates list so concurrent shows would appear in ascending order
- updated readme
- updated .gitignore